### PR TITLE
Release 2.0.0

### DIFF
--- a/packaging/rpm/Makefile
+++ b/packaging/rpm/Makefile
@@ -1,6 +1,6 @@
 PACKAGE_NAME?=	redborder-cep
 
-VERSION?=	$(shell git describe --abbrev=6 --tags HEAD --always | sed 's/-/_/g' | sed -e 's/cep_//')
+VERSION?=	$(shell git describe --abbrev=6 --tags HEAD --always | sed 's/-/_/g')
 
 BUILD_NUMBER?= 1
 

--- a/packaging/rpm/redborder-cep.spec
+++ b/packaging/rpm/redborder-cep.spec
@@ -50,6 +50,8 @@ systemctl daemon-reload
 /usr/lib/systemd/system/redborder-cep.service
 
 %changelog
+* Thu Mar 21 2024 Vicente Mesa <vimesa@redborder.com> - 2.0.0-1
+- Don't build the debug package
 * Tue Feb 8 2022 Javier Rodriguez  <javiercrg@redborder.com> - 1.0.1-1
 * Fri Jun 17 2016 Carlos J. Mateos  <cjmateos@redborder.com> - 1.0.0-1
 - first spec version


### PR DESCRIPTION
New in this release:

- Updated dependencies in `pom.xml`
- Don't build the debug package
- Don't erase 'cep_' from the package version (previous tags included it and the new tag doesn't, so it's not necessary)